### PR TITLE
Do not exit when table store drops the connection

### DIFF
--- a/gohaveazurestoragecommon/http.go
+++ b/gohaveazurestoragecommon/http.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
-	"os"
 	"strings"
 	"time"
 )
@@ -66,8 +65,7 @@ func (storagehttp *HTTP) Request(httpVerb string, target string, query string, j
 
 	response, err := client.Do(request)
 	if err != nil {
-		fmt.Printf("%s", err)
-		os.Exit(1)
+		return nil, http.StatusServiceUnavailable
 	}
 
 	if storagehttp.dumpSessions {
@@ -81,8 +79,7 @@ func (storagehttp *HTTP) Request(httpVerb string, target string, query string, j
 
 	contents, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		fmt.Printf("%s", err)
-		os.Exit(1)
+		return nil, http.StatusUnprocessableEntity
 	}
 
 	return contents, response.StatusCode


### PR DESCRIPTION
The `os.Exit(1)` doesn't allow a user to control what to do on an error, like a retry for example. Stopping the program execution is a major problem when running long running jobs like an import.

While it would be cleaner to return the actual error this change keeps the API compatibility and gives a good indication of the failure. Where for further debugging the `dumpSessions` is still available.